### PR TITLE
Add possibility to mock IO functions

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -60,6 +60,14 @@ config :git_hooks,
     ]
   ]
 
+config :archethic,
+       Archethic.Contracts.Interpreter.Library.Common.Chain,
+       ArchethicPlayground.MockFunctions
+
+config :archethic,
+       Archethic.Contracts.Interpreter.Library.Common.Token,
+       ArchethicPlayground.MockFunctions
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env()}.exs"

--- a/lib/archethic_playground/mock_functions.ex
+++ b/lib/archethic_playground/mock_functions.ex
@@ -1,0 +1,25 @@
+defmodule ArchethicPlayground.MockFunctions do
+  @moduledoc false
+  @behaviour Archethic.Contracts.Interpreter.Library.Common.Chain
+  @behaviour Archethic.Contracts.Interpreter.Library.Common.Token
+
+  @impl Archethic.Contracts.Interpreter.Library.Common.Chain
+  def get_genesis_address(address) do
+    Process.get("Chain.get_genesis_address_#{address}")
+  end
+
+  @impl Archethic.Contracts.Interpreter.Library.Common.Chain
+  def get_first_transaction_address(address) do
+    Process.get("Chain.get_first_transaction_address_#{address}")
+  end
+
+  @impl Archethic.Contracts.Interpreter.Library.Common.Chain
+  def get_genesis_public_key(public_key) do
+    Process.get("Chain.get_genesis_public_key_#{public_key}")
+  end
+
+  @impl Archethic.Contracts.Interpreter.Library.Common.Token
+  def fetch_id_from_address(address) do
+    Process.get("Token.fetch_id_from_address_#{address}")
+  end
+end

--- a/lib/archethic_playground_web/live/components/trigger_component.ex
+++ b/lib/archethic_playground_web/live/components/trigger_component.ex
@@ -3,7 +3,6 @@ defmodule ArchethicPlaygroundWeb.TriggerComponent do
 
   use ArchethicPlaygroundWeb, :live_component
 
-  alias Archethic.Contracts.ContractConstants, as: Constants
   alias Archethic.Contracts
   alias Archethic.Contracts.Contract
   alias Archethic.TransactionChain.Transaction
@@ -17,7 +16,7 @@ defmodule ArchethicPlaygroundWeb.TriggerComponent do
             <div class="absolute inset-0 px-2 sm:px-2">
                 <div class="h-full border-2 border border-gray-500 bg-black text-gray-200 p-4 overflow-y-auto">
                     <div class="block">
-                        <.form :let={f} for={%{}} as={:form} phx-submit="execute_action" phx-change="update_form" phx-target={@myself} class="w-full max-w-lg">
+                        <.form :let={f} for={%{}} as={:form} phx-submit="execute_trigger" phx-change="update_form" phx-target={@myself} class="w-full max-w-lg">
                             <div class="flex flex-wrap -mx-3 mb-6">
                             <div class="w-full px-3">
                                 <label class="block uppercase tracking-wide text-xs font-bold mb-2" for="triggers">
@@ -35,18 +34,65 @@ defmodule ArchethicPlaygroundWeb.TriggerComponent do
                                 </div>
                             <% end %>
                             </div>
-                            <%= unless @display_transaction_form do %>
-                              <%= submit "Trigger", disabled: @selected_trigger == "", class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline" %>
-                            <% end %>
+                            <div class="mt-5">
+                            MOCK FUNCTIONS
+                              <label class="block uppercase tracking-wide text-xs font-bold mb-2" for="triggers">
+                                Select the function you want to mock
+                              </label>
+                              <%= select f, :new_mock_function, @mock_functions, value: @new_mock_function, id: "mock_functions", prompt: "Select a function to mock", class: "appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500" %>
+                              <%= if @new_mock_function != "Time.now" do %>
+                                <label class="block uppercase tracking-wide text-xs font-bold mb-2" for="mock-input">
+                                  Input
+                                </label>
+                                <%= text_input f, :new_mock_input, value: @new_mock_input, id: "mock-input", class: "appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500"  %>
+                              <% end %>
+                              <label class="block uppercase tracking-wide text-xs font-bold mb-2" for="mock-output">
+                                Output
+                              </label>
+                              <%= text_input f, :new_mock_output, value: @new_mock_output, id: "mock-output", class: "appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500"  %>
+                              <div class="mt-5">
+                                <a phx-click="add_mock_function" phx-target={@myself} class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline" href="#">
+                                  Add
+                                </a>
+                              </div>
+                              <div class="mt-5">
+                              <%= for mock_function <- @configured_mock_functions do %>
+                                <div class="border border-gray-200 p-4 my-5">
+                                  <div><span class="font-bold">Name:</span> <%= mock_function.function_name %></div>
+                                  <%= if mock_function.function_name != "Time.now" do %>
+                                    <div class="mb-2">
+                                      <span class="font-bold">Input:</span>
+                                      <span title={mock_function.input}><%= truncate_string(mock_function.input) %></span>
+                                    </div>
+                                  <% end %>
+                                  <div class="mb-2">
+                                    <span class="font-bold">Output:</span>
+                                    <span title={mock_function.output}><%= truncate_string(mock_function.output) %></span>
+                                  </div>
+                                  <div>
+                                    <a phx-click="remove_mock_function"
+                                      phx-value-function_name={mock_function.function_name}
+                                      phx-value-input={mock_function.input}
+                                      phx-value-output={mock_function.output}
+                                      phx-target={@myself}
+                                      class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
+                                      href="#">
+                                      Delete
+                                    </a>
+                                  </div>
+                                </div>
+                              <% end %>
+                              </div>
+                            </div>
                         </.form>
                         <%= if @display_transaction_form do %>
-                          <.live_component module={CreateTransactionComponent} id="create-transaction-trigger" module_to_update={__MODULE__} id_to_update="trigger_component" smart_contract_code={@smart_contract_code} aes_key={@aes_key} />
-                          <div class="mt-5">
-                            <a phx-click="execute_transaction" phx-target={@myself} class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline" href="#">
-                              Trigger
-                            </a>
-                          </div>
+                          <.live_component module={CreateTransactionComponent} id="create-transaction-trigger" module_to_update={__MODULE__} id_to_update="trigger_component" smart_contract_code={@smart_contract_code} aes_key={@aes_key} display_validation_timestamp_input={true} />
                         <% end %>
+                        <div class="mt-5">
+                            <button phx-click="execute_trigger" disabled={@selected_trigger == ""} phx-target={@myself} class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline" href="#">
+                              Trigger
+                            </button>
+                          </div>
                     </div>
                 </div>
             </div>
@@ -63,12 +109,26 @@ defmodule ArchethicPlaygroundWeb.TriggerComponent do
       |> assign(:selected_trigger, "")
       |> assign(:transaction, nil)
       |> assign(:aes_key, :crypto.strong_rand_bytes(32))
+      |> assign(:mock_functions, [
+        "Chain.get_genesis_address",
+        "Chain.get_first_transaction_address",
+        "Chain.get_genesis_public_key",
+        "Time.now",
+        "Token.fetch_id_from_address"
+      ])
+      |> assign(:new_mock_function, "")
+      |> assign(:new_mock_input, "")
+      |> assign(:new_mock_output, "")
+      |> assign(:configured_mock_functions, [])
 
     {:ok, socket}
   end
 
   def handle_event("update_form", params, socket) do
     trigger_form = params["form"]["trigger"]
+    new_mock_function = params["form"]["new_mock_function"]
+    new_mock_input = params["form"]["new_mock_input"]
+    new_mock_output = params["form"]["new_mock_output"]
     display_transaction_form = trigger_form == "transaction"
     display_oracle_form = trigger_form == "oracle"
 
@@ -77,14 +137,63 @@ defmodule ArchethicPlaygroundWeb.TriggerComponent do
       |> assign(:display_transaction_form, display_transaction_form)
       |> assign(:display_oracle_form, display_oracle_form)
       |> assign(:selected_trigger, trigger_form)
+      |> assign(:new_mock_function, new_mock_function)
+      |> assign(:new_mock_input, new_mock_input)
+      |> assign(:new_mock_output, new_mock_output)
 
     {:noreply, socket}
   end
 
-  def handle_event("execute_action", %{"form" => %{"trigger" => trigger_form}}, socket) do
-    # this is the opposite of EditorLive.get_key/1
+  def handle_event("add_mock_function", _, socket) do
+    new_mock_function = socket.assigns.new_mock_function
+    new_mock_input = socket.assigns.new_mock_input
+    new_mock_output = socket.assigns.new_mock_output
+
+    if new_mock_function != "" and new_mock_input != "" and new_mock_output != "" do
+      add_mock_function(new_mock_function, new_mock_input, new_mock_output)
+
+      socket =
+        socket
+        |> assign(:new_mock_function, "")
+        |> assign(:new_mock_input, "")
+        |> assign(:new_mock_output, "")
+        |> assign(
+          :configured_mock_functions,
+          socket.assigns.configured_mock_functions ++
+            [%{function_name: new_mock_function, input: new_mock_input, output: new_mock_output}]
+        )
+
+      {:noreply, socket}
+    else
+      send(self(), {:console, :clear})
+      send(self(), {:console, %{"error" => "Please fill-in the mock function form"}})
+      {:noreply, socket}
+    end
+  end
+
+  def handle_event("remove_mock_function", params, socket) do
+    function_name = params["function_name"]
+    input = params["input"]
+    output = params["output"]
+
+    socket =
+      socket
+      |> assign(
+        :configured_mock_functions,
+        socket.assigns.configured_mock_functions
+        |> Enum.reject(fn mock_function ->
+          mock_function.function_name == function_name and mock_function.input == input and
+            mock_function.output == output
+        end)
+      )
+
+    remove_mock_function(function_name, input)
+    {:noreply, socket}
+  end
+
+  def handle_event("execute_trigger", _, socket) do
     trigger =
-      case trigger_form do
+      case socket.assigns.selected_trigger do
         "oracle" ->
           :oracle
 
@@ -93,44 +202,44 @@ defmodule ArchethicPlaygroundWeb.TriggerComponent do
 
         key_with_param ->
           key_with_param
-          |> String.split(":")
-          |> case do
-            ["interval", value] ->
-              {:interval, value}
-
-            ["datetime", value] ->
-              {value, _} = Integer.parse(value)
-              {:datetime, DateTime.from_unix!(value)}
-          end
+          |> parse_key_with_param()
       end
 
+    handle_trigger(trigger, socket.assigns.transaction, socket)
+  end
+
+  defp parse_key_with_param(key_with_param) do
+    [key | rest] = String.split(key_with_param, ":")
+
+    case key do
+      "interval" -> {:interval, List.first(rest)}
+      "datetime" -> {:datetime, parse_datetime(List.first(rest))}
+    end
+  end
+
+  defp parse_datetime(value) do
+    {parsed_value, _} = Integer.parse(value)
+    DateTime.from_unix!(parsed_value)
+  end
+
+  defp handle_trigger(:transaction, nil, socket) do
+    send(self(), {:console, :clear})
+    send(self(), {:console, %{"error" => "Please fill-in the transaction form"}})
+    {:noreply, socket}
+  end
+
+  defp handle_trigger(trigger, transaction, socket) do
     execute_contract(
       trigger,
       socket.assigns.interpreted_contract,
-      nil
+      transaction,
+      socket.assigns.configured_mock_functions
     )
 
     {:noreply, socket}
   end
 
-  def handle_event("execute_transaction", _, socket) do
-    case socket.assigns.transaction do
-      nil ->
-        send(self(), {:console, :clear})
-        send(self(), {:console, %{"error" => "Please fill-in the transaction form"}})
-
-      tx ->
-        execute_contract(
-          :transaction,
-          socket.assigns.interpreted_contract,
-          Constants.to_transaction(tx)
-        )
-    end
-
-    {:noreply, socket}
-  end
-
-  def update(%{transaction_map: transaction}, socket) do
+  def update(%{transaction: transaction}, socket) do
     socket = assign(socket, transaction: transaction)
     {:ok, socket}
   end
@@ -139,12 +248,11 @@ defmodule ArchethicPlaygroundWeb.TriggerComponent do
     {:ok, assign(socket, assigns)}
   end
 
-  defp execute_contract(trigger, contract, maybe_tx) do
+  defp execute_contract(trigger, contract, maybe_tx, configured_mock_functions) do
     send(self(), {:console, :clear})
     send(self(), {:console, "Executing contract trigger: #{inspect(trigger)}"})
 
-    # TO DO: the time to use should be set-able by the user
-    datetime = DateTime.utc_now()
+    datetime = get_time_now(configured_mock_functions)
 
     with :ok <- check_valid_precondition(trigger, contract, maybe_tx, datetime),
          {:ok, tx_or_nil} <-
@@ -157,7 +265,21 @@ defmodule ArchethicPlaygroundWeb.TriggerComponent do
     end
   end
 
-  ###########
+  defp get_time_now(configured_mock_functions) do
+    date_time_now =
+      Enum.find(configured_mock_functions, fn %{function_name: function_name} ->
+        function_name == "Time.now"
+      end)
+
+    case date_time_now do
+      nil ->
+        DateTime.utc_now()
+
+      _ ->
+        DateTime.from_unix!(String.to_integer(date_time_now.output))
+    end
+  end
+
   defp check_valid_precondition(
          :oracle,
          contract = %Contract{},
@@ -200,4 +322,28 @@ defmodule ArchethicPlaygroundWeb.TriggerComponent do
   end
 
   defp check_valid_postcondition(_, _, _), do: :ok
+
+  defp add_mock_function(function_name, input, output) do
+    get_mock_key_name(function_name, input) |> Process.put(output)
+  end
+
+  defp remove_mock_function(function_name, input) do
+    get_mock_key_name(function_name, input) |> Process.delete()
+  end
+
+  defp get_mock_key_name(function_name, input) do
+    "#{function_name}_#{input}"
+  end
+
+  defp truncate_string(""), do: ""
+
+  defp truncate_string(s) when is_binary(s) do
+    if String.length(s) > 15 do
+      String.slice(s, 0..15) <> "..."
+    else
+      s
+    end
+  end
+
+  defp truncate_string(s), do: s
 end

--- a/lib/archethic_playground_web/live/components/trigger_component.ex
+++ b/lib/archethic_playground_web/live/components/trigger_component.ex
@@ -86,7 +86,7 @@ defmodule ArchethicPlaygroundWeb.TriggerComponent do
                             </div>
                         </.form>
                         <%= if @display_transaction_form do %>
-                          <.live_component module={CreateTransactionComponent} id="create-transaction-trigger" module_to_update={__MODULE__} id_to_update="trigger_component" smart_contract_code={@smart_contract_code} aes_key={@aes_key} display_validation_timestamp_input={true} />
+                          <.live_component module={CreateTransactionComponent} id="create-transaction-trigger" module_to_update={__MODULE__} id_to_update="trigger_component" smart_contract_code={@smart_contract_code} aes_key={@aes_key} display_mock_values_input={true} />
                         <% end %>
                         <div class="mt-5">
                             <button phx-click="execute_trigger" disabled={@selected_trigger == ""} phx-target={@myself} class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline" href="#">


### PR DESCRIPTION
⚠️ Merge [this PR](https://github.com/archethic-foundation/archethic-node/pull/1146) and update the dependencies before merging this one.

The goal of this PR is to give the possibility to mock IO functions calls when executing triggers (the calls are made in the smart contract to trigger).

List of supported functions:
From `Archethic.Contracts.Interpreter.Library.Common.Chain`
- `get_genesis_address(address)`
- `get_first_transaction_address(address)`
- `get_genesis_public_key(public_key)`

From `Archethic.Contracts.Interpreter.Library.Common.Token`
- `fetch_id_from_address(address)`

The PR also supports the `Time.now` function.

The mock mechanism relies on `Process.put` `Process.get` to set the value to mock for the current process.

One last thing that this PR supports is the possibility to mock calls to `transaction.timestamp` which refers to the `transaction.validation_stamp.timestamp`.

Closes #49 