### PR TITLE
Prevent parser to crash live view

### DIFF
--- a/lib/archethic_playground.ex
+++ b/lib/archethic_playground.ex
@@ -8,10 +8,16 @@ defmodule ArchethicPlayground do
 
   alias ArchethicPlayground.Transaction, as: PlaygroundTransaction
 
+  require Logger
+
   def parse(transaction_contract) do
     transaction_contract
     |> PlaygroundTransaction.to_archethic()
     |> Contracts.from_transaction()
+  rescue
+    error ->
+      Logger.error(Exception.format(:error, error, __STACKTRACE__))
+      {:error, "Unexpected error #{inspect(error)}"}
   end
 
   def execute(transaction_contract, trigger_form) do

--- a/lib/archethic_playground_web/live/editor_live.ex
+++ b/lib/archethic_playground_web/live/editor_live.ex
@@ -146,6 +146,10 @@ defmodule ArchethicPlaygroundWeb.EditorLive do
         {:error, :contract_failure} ->
           send(self(), {:console, :error, "Contract's execution failed"})
           socket
+
+        {:error, message} when is_binary(message) ->
+          send(self(), {:console, :error, message})
+          socket
       end
 
     {:noreply, socket}


### PR DESCRIPTION
Ad a try catch on parser to prevent crashing live view if parser raise an error