### PR TITLE
Adapt to node v1.3.1

### DIFF
--- a/assets/js/editor/language.js
+++ b/assets/js/editor/language.js
@@ -105,7 +105,7 @@ export async function setLanguage(monaco) {
         {
           label: 'Contract.add_uco_transfers/1',
           kind: monaco.languages.CompletionItemKind.Snippet,
-          insertText: 'Contract.add_uco_transfers [\n\t[to: ${1:0x0000...}, amount: ${2:amount}],\n\t[to: ${3:0x0000...}, amount: ${4:amount}]\n]',
+          insertText: 'Contract.add_uco_transfers [\n\t[to: ${1:0x0000...}, amount: ${2:amount}]\n]',
           insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
           documentation: 'Adds multiple UCO transfers'
         },
@@ -126,30 +126,69 @@ export async function setLanguage(monaco) {
         {
           label: 'Contract.add_token_transfers/1',
           kind: monaco.languages.CompletionItemKind.Snippet,
-          insertText: 'Contract.add_token_transfers [\n\t[to: ${1:0x0000...}, token_address: ${2:0x0000...}, amount: ${3:amount}],\n\t[to: ${4:0x0000...}, token_address: ${5:0x0000...}, amount: ${6:amount}]\n]',
+          insertText: 'Contract.add_token_transfers [\n\t[to: ${1:0x0000...}, token_address: ${2:0x0000...}, amount: ${3:amount}]\n]',
           insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
           documentation: 'Adds multiple token transfers'
         },
         {
           label: 'Contract.add_recipient/1',
           kind: monaco.languages.CompletionItemKind.Snippet,
-          insertText: 'Contract.add_recipient "${1:0x0000...}"',
+          insertText: 'Contract.add_recipient ${1:0x0000...}',
           insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
           documentation: 'Adds a recipient'
         },
         {
           label: 'Contract.add_recipient/3',
           kind: monaco.languages.CompletionItemKind.Snippet,
-          insertText: 'Contract.add_recipient address: "${1:0x0000...}", action: "${2:vote}", args: ["${3:John}"]',
+          insertText: 'Contract.add_recipient address: ${1:0x0000...}, action: "${2:vote}", args: ["${3:John}"]',
           insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
           documentation: 'Adds a recipient'
         },
         {
           label: 'Contract.add_recipients/1',
           kind: monaco.languages.CompletionItemKind.Snippet,
-          insertText: 'Contract.add_recipients [\n\t[address: "${1:0x0000...}", action: "${2:vote}", args: ["${3:John}"]],\n\t[address: "${4:0x0000...}", action: "${5:vote}", args: ["${6:John}"]]\n]',
+          insertText: 'Contract.add_recipients [\n\t[address: ${1:0x0000...}, action: "${2:vote}", args: ["${3:John}"]]\n]',
           insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
           documentation: 'Adds multiple contracts\' recipients'
+        },
+        {
+          label: 'Contract.add_ownership/2',
+          kind: monaco.languages.CompletionItemKind.Snippet,
+          insertText:
+            [
+              'Contract.add_ownership(',
+              '  secret: ${1:0x...},',
+              '  authorized_keys:',
+              '    Map.set(Map.new(),',
+              '      # public_key',
+              '      ${2:0x0000...},',
+              '      # encryption key',
+              '      ${3:0x...}',
+              '    )',
+              ')',
+            ].join('\n'),
+          insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
+          documentation: 'Adds a ownership'
+        },
+        {
+          label: 'Contract.add_ownerships/1',
+          kind: monaco.languages.CompletionItemKind.Snippet,
+          insertText: [
+            'Contract.add_ownerships([',
+            '  [',
+            '    secret: ${1:0x...},',
+            '    authorized_keys:',
+            '      Map.set(Map.new(),',
+            '        # public_key',
+            '        ${2:0x0000...},',
+            '        # encryption key',
+            '        ${3:0x...}',
+            '      )',
+            '  ]',
+            '])',
+          ].join('\n'),
+          insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
+          documentation: 'Adds multiple ownerships'
         },
         {
           label: 'Contract.set_type/1',

--- a/config/config.exs
+++ b/config/config.exs
@@ -77,6 +77,10 @@ config :archethic,
        Archethic.Contracts.Interpreter.Library.Common.Contract,
        ArchethicPlayground.MockFunctions
 
+config :archethic,
+       Archethic.Crypto.SharedSecretsKeystore,
+       ArchethicPlayground.MockFunctions
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env()}.exs"

--- a/config/config.exs
+++ b/config/config.exs
@@ -81,6 +81,10 @@ config :archethic,
        Archethic.Crypto.SharedSecretsKeystore,
        ArchethicPlayground.MockFunctions
 
+config :archethic,
+       Archethic.Crypto.NodeKeystore.Origin,
+       ArchethicPlayground.MockFunctions
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env()}.exs"

--- a/lib/archethic_playground.ex
+++ b/lib/archethic_playground.ex
@@ -2,6 +2,7 @@ defmodule ArchethicPlayground do
   @moduledoc """
   Main module to run the functionality needed
   """
+  alias Archethic.Crypto
   alias Archethic.Contracts
   alias Archethic.Contracts.Contract
   alias Archethic.TransactionChain.Transaction
@@ -16,6 +17,10 @@ defmodule ArchethicPlayground do
   @spec parse(PlaygroundTransaction.t()) :: {:ok, Contract.t()} | {:error, String.t()}
   def parse(transaction_contract) do
     transaction_contract
+    |> PlaygroundTransaction.add_contract_ownership(
+      transaction_contract.seed,
+      Crypto.storage_nonce_public_key() |> Base.encode16()
+    )
     |> PlaygroundTransaction.to_archethic()
     |> Contracts.from_transaction()
   rescue
@@ -103,7 +108,12 @@ defmodule ArchethicPlayground do
              time_now: datetime
            ),
          :ok <- check_valid_postcondition(contract, tx_or_nil, datetime),
-         tx_or_nil <- PlaygroundTransaction.from_archethic(tx_or_nil) do
+         tx_or_nil <-
+           PlaygroundTransaction.from_archethic(
+             tx_or_nil,
+             transaction_contract.seed,
+             1 + transaction_contract.index
+           ) do
       {:ok, tx_or_nil}
     end
   catch

--- a/lib/archethic_playground/mock_functions.ex
+++ b/lib/archethic_playground/mock_functions.ex
@@ -13,6 +13,12 @@ defmodule ArchethicPlayground.MockFunctions do
     Enum.each(mocks, &add_mock/1)
   end
 
+  # not declaring the behaviour (Archethic.Crypto.SharedSecretsKeystore)
+  # because we'd have to declare plenty of function we dont care about
+  def get_storage_nonce() do
+    :crypto.strong_rand_bytes(34)
+  end
+
   # this is not mockable but still part of the behaviour
   @impl Library.Common.Chain
   def get_burn_address() do

--- a/lib/archethic_playground/mock_functions.ex
+++ b/lib/archethic_playground/mock_functions.ex
@@ -14,9 +14,16 @@ defmodule ArchethicPlayground.MockFunctions do
   end
 
   # not declaring the behaviour (Archethic.Crypto.SharedSecretsKeystore)
-  # because we'd have to declare plenty of function we dont care about
+  # because we'd have to declare plenty of functions we dont care about
   def get_storage_nonce() do
-    :crypto.strong_rand_bytes(34)
+    <<151, 26, 71, 190, 21, 114, 94, 13, 165, 41, 21, 146, 134, 93, 31, 207, 81, 207, 166, 38, 4,
+      208, 28, 163, 18, 245, 213, 41, 139, 109, 204, 30, 218, 29>>
+  end
+
+  # not declaring the behaviour (Archethic.Crypto.NodeKeystore.Origin )
+  # because we'd have to declare plenty of functions we dont care about
+  def sign_with_origin_key(_data) do
+    :crypto.strong_rand_bytes(64)
   end
 
   # this is not mockable but still part of the behaviour

--- a/lib/archethic_playground/transaction/ownership/encrypted_key_by_authorized_key.ex
+++ b/lib/archethic_playground/transaction/ownership/encrypted_key_by_authorized_key.ex
@@ -1,0 +1,23 @@
+defmodule ArchethicPlayground.Transaction.Ownership.EncryptedKeyByAuthorizedKey do
+  @moduledoc false
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @type t :: %__MODULE__{
+          public_key: String.t(),
+          encrypted_key: String.t()
+        }
+
+  @derive {Jason.Encoder, except: [:id]}
+  embedded_schema do
+    field(:public_key, :string)
+    field(:encrypted_key, :string)
+  end
+
+  @doc false
+  def changeset(changeset, params = %{}) do
+    changeset
+    |> cast(params, [:public_key, :encrypted_key])
+    |> validate_required([:public_key, :encrypted_key])
+  end
+end

--- a/lib/archethic_playground/utils/address.ex
+++ b/lib/archethic_playground/utils/address.ex
@@ -1,5 +1,19 @@
 defmodule ArchethicPlayground.Utils.Address do
   @moduledoc false
 
+  alias Archethic.Crypto
+
   def random(), do: <<0::8, 0::8, :crypto.strong_rand_bytes(32)::binary>>
+
+  def from_seed_index(seed, index) do
+    seed
+    |> Crypto.derive_keypair(index)
+    |> elem(0)
+    |> Crypto.derive_address()
+    |> Base.encode16()
+  end
+
+  def from_transaction(%ArchethicPlayground.Transaction{seed: seed, index: index}) do
+    from_seed_index(seed, index)
+  end
 end

--- a/lib/archethic_playground_web/live/components/deploy_component.ex
+++ b/lib/archethic_playground_web/live/components/deploy_component.ex
@@ -225,8 +225,8 @@ defmodule ArchethicPlaygroundWeb.DeployComponent do
       nil
     else
       # assumption that contract is deployed at index 1 (to be changed later by using chain_length+1)
-      contract_address = seed_to_address(seed, 1)
-      genesis_address = seed_to_address(seed, 0)
+      contract_address = Utils.Address.from_seed_index(seed, 1)
+      genesis_address = Utils.Address.from_seed_index(seed, 0)
 
       uri = URI.parse(endpoint)
       contract_url = URI.to_string(%URI{uri | path: "/explorer/transaction/#{contract_address}"})
@@ -239,13 +239,5 @@ defmodule ArchethicPlaygroundWeb.DeployComponent do
         genesis_url: genesis_url
       }
     end
-  end
-
-  defp seed_to_address(seed, idx) do
-    seed
-    |> Crypto.derive_keypair(idx)
-    |> elem(0)
-    |> Crypto.derive_address()
-    |> Base.encode16()
   end
 end

--- a/lib/archethic_playground_web/live/components/mock_form_component/contract_call_function3.ex
+++ b/lib/archethic_playground_web/live/components/mock_form_component/contract_call_function3.ex
@@ -20,7 +20,16 @@ defmodule ArchethicPlaygroundWeb.MockFormComponent.ContractCallFunction3 do
   end
 
   def handle_event("add-argument", _params, socket) do
-    params = update_in(socket.assigns.form.params, ["args"], fn args -> args ++ [""] end)
+    params = update_in(socket.assigns.form.params, ["args"], &(&1 ++ [""]))
+
+    {:noreply, assign_form(socket, params)}
+  end
+
+  def handle_event("remove-argument", %{"index" => index}, socket) do
+    index = String.to_integer(index)
+
+    params = update_in(socket.assigns.form.params, ["args"], &List.delete_at(&1, index))
+
     {:noreply, assign_form(socket, params)}
   end
 

--- a/lib/archethic_playground_web/live/components/mock_form_component/contract_call_function3.html.heex
+++ b/lib/archethic_playground_web/live/components/mock_form_component/contract_call_function3.html.heex
@@ -7,11 +7,17 @@
 
     <div :for={{value, i} <- Enum.with_index(input_value(@form, :args))}>
       <div phx-feedback-for={"args[#{i}]"} class="pc-form-field-wrapper phx-no-feedback">
-        <label class="pc-label ">#<%= i+1 %></label>
+        <label class="pc-label ">#<%= i + 1 %></label>
 
         <div class="flex flex-row">
-          <input type="text" name={"args[#{i}]"} value={value} class="w-11/12 pc-text-input">
-          <.icon name={:trash} phx-click="remove-argument" phx-value-index={i} phx-target={@myself} class="w-1/12 h-9 cursor-pointer text-gray-500" />
+          <textarea name={"args[#{i}]"} class="w-11/12 pc-text-input"><%= value %></textarea>
+          <.icon
+            name={:trash}
+            phx-click="remove-argument"
+            phx-value-index={i}
+            phx-target={@myself}
+            class="w-1/12 h-9 cursor-pointer text-gray-500"
+          />
         </div>
 
         <div class="pc-form-help-text ">
@@ -32,6 +38,6 @@
     />
 
     <hr style="width: 80%; border: 1px dashed rgb(75 85 99); margin: 1em auto" />
-    <.field field={@form[:result]} type="text" label="Result" />
+    <.field field={@form[:result]} type="textarea" label="Result" />
   </.form>
 </div>

--- a/lib/archethic_playground_web/live/components/transaction_form_component.ex
+++ b/lib/archethic_playground_web/live/components/transaction_form_component.ex
@@ -70,15 +70,15 @@ defmodule ArchethicPlaygroundWeb.TransactionFormComponent do
     |> Transaction.remove_ownership_at(index)
   end
 
-  def on("add-ownership-public-key", %{"ownership-index" => ownership_index}, transaction) do
+  def on("add-ownership-authorized-key", %{"ownership-index" => ownership_index}, transaction) do
     ownership_index = String.to_integer(ownership_index)
 
     transaction
-    |> Transaction.add_empty_public_key_on_ownership_at(ownership_index)
+    |> Transaction.add_empty_authorized_key_on_ownership_at(ownership_index)
   end
 
   def on(
-        "remove-ownership-public-key",
+        "remove-ownership-authorized-key",
         %{"ownership-index" => ownership_index, "public-key-index" => public_key_index},
         transaction
       ) do
@@ -86,7 +86,7 @@ defmodule ArchethicPlaygroundWeb.TransactionFormComponent do
     public_key_index = String.to_integer(public_key_index)
 
     transaction
-    |> Transaction.remove_public_key_on_ownership_at(ownership_index, public_key_index)
+    |> Transaction.remove_authorized_key_on_ownership_at(ownership_index, public_key_index)
   end
 
   defp list_transaction_types() do

--- a/lib/archethic_playground_web/live/components/transaction_form_component.html.heex
+++ b/lib/archethic_playground_web/live/components/transaction_form_component.html.heex
@@ -1,5 +1,7 @@
 <div>
   <.form :let={f} for={@form} phx-change="transaction_form:on-form-change" phx-target={@parent}>
+    <.field field={@form[:seed]} type="hidden" />
+    <.field field={@form[:index]} type="hidden" />
     <.field field={@form[:type]} type="select" options={list_transaction_types()} label="Type*" />
 
     <.field field={@form[:content]} type="textarea" label="Content" />
@@ -17,11 +19,18 @@
         label="Validation UTC time"
         help_text={"Used to mock #{@global_variable}.timestamp"}
       />
-      <.field
-        field={@form[:address]}
-        label="Address"
-        help_text={"Used to mock #{@global_variable}.address"}
-      />
+      <div class="pc-form-field-wrapper">
+        <label class="pc-label">Address</label>
+        <input
+          type="text"
+          class="pc-text-input"
+          value={ArchethicPlayground.Utils.Address.from_seed_index(input_value(f, :seed), input_value(f, :index))}
+          disabled
+        />
+        <div class="pc-form-help-text ">
+          Used to mock <%= @global_variable %>.address
+        </div>
+      </div>
     <% end %>
 
     <.card class="mb-2">
@@ -174,32 +183,52 @@
           class="w-full"
         />
 
+        <%= if length(input_value(f, :ownerships)) > 0 do %>
+        <div class="pc-form-help-text ">
+          You must encode the secret with an AES key.<br/>
+          Then you must encrypt the AES key for each public key.
+
+          <a href="https://wiki.archethic.net/learn/cryptography/" target="_blank">
+            <.icon
+              name={:question_mark_circle}
+              class="inline text-gray-500 cursor-pointer w-6 h-6"
+            />
+          </a>
+        </div>
+        <% end %>
+
         <%= for ownership_form <- inputs_for f, :ownerships do %>
           <%= hidden_inputs_for(ownership_form) %>
           <div class="flex gap-1 my-2 p-1 border border-gray-700 rounded">
             <div class="w-11/12 flex flex-col gap-1">
               <%= text_input(ownership_form, :secret,
                 class: "pc-text-input",
-                placeholder: "Secret"
+                placeholder: "Encoded secret"
               ) %>
 
-              <% # pure html to deal with this nested list %>
-              <%= for {key, public_key_index} <- Enum.with_index(input_value(ownership_form, :authorized_keys) || []) do %>
+              <%= for authorized_key_form <- inputs_for ownership_form, :authorized_keys do %>
                 <div class="flex">
                   <input
-                    name={input_name(ownership_form, :authorized_keys) <> "[]"}
+                    name={input_name(authorized_key_form, :public_key)}
                     type="text"
-                    value={key}
+                    value={input_value(authorized_key_form, :public_key)}
                     class="pc-text-input w-11/12"
                     placeholder="Public key"
+                  />
+                  <input
+                    name={input_name(authorized_key_form, :encrypted_key)}
+                    type="text"
+                    value={input_value(authorized_key_form, :encrypted_key)}
+                    class="pc-text-input w-11/12"
+                    placeholder="Encoded encryption key"
                   />
                   <div class="w-1/12 flex flex-col place-content-center">
                     <.icon
                       name={:trash}
                       class="cursor-pointer"
-                      phx-click="transaction_form:remove-ownership-public-key"
+                      phx-click="transaction_form:remove-ownership-authorized-key"
                       phx-value-ownership-index={ownership_form.index}
-                      phx-value-public-key-index={public_key_index}
+                      phx-value-public-key-index={authorized_key_form.index}
                       phx-target={@parent}
                     />
                   </div>
@@ -211,7 +240,7 @@
               <.icon
                 name={:plus}
                 class="cursor-pointer"
-                phx-click="transaction_form:add-ownership-public-key"
+                phx-click="transaction_form:add-ownership-authorized-key"
                 phx-value-ownership-index={ownership_form.index}
                 phx-target={@parent}
               />

--- a/lib/archethic_playground_web/live/components/trigger_component.ex
+++ b/lib/archethic_playground_web/live/components/trigger_component.ex
@@ -51,8 +51,6 @@ defmodule ArchethicPlaygroundWeb.TriggerComponent do
               TriggerForm.deserialize_trigger(trigger_str)
           end
 
-        random_address = Utils.Address.random() |> Base.encode16()
-
         case trigger do
           :oracle ->
             TriggerForm.changeset(previous_trigger_form, trigger_form)
@@ -60,7 +58,6 @@ defmodule ArchethicPlaygroundWeb.TriggerComponent do
             |> TriggerForm.set_transaction(
               Transaction.new(%{
                 "type" => "oracle",
-                "address" => random_address,
                 "content" => Jason.encode!(%{"uco" => %{"usd" => "0.934", "eur" => "0.911"}})
               })
             )
@@ -70,22 +67,21 @@ defmodule ArchethicPlaygroundWeb.TriggerComponent do
             |> TriggerForm.remove_recipient()
             |> TriggerForm.set_transaction(
               Transaction.new(%{
-                "type" => "data",
-                "address" => random_address
+                "type" => "data"
               })
             )
 
           {:transaction, action, args_names} ->
             TriggerForm.changeset(previous_trigger_form, trigger_form)
             |> TriggerForm.set_recipient(%RecipientForm{
-              address: socket.assigns.contract_address,
+              address:
+                ArchethicPlayground.Utils.Address.from_transaction(socket.assigns.transaction),
               action: action,
               args: Enum.map(args_names, &%KeyValue{key: &1, value: ""})
             })
             |> TriggerForm.set_transaction(
               Transaction.new(%{
-                "type" => "data",
-                "address" => random_address
+                "type" => "data"
               })
             )
 

--- a/lib/archethic_playground_web/live/editor_live.ex
+++ b/lib/archethic_playground_web/live/editor_live.ex
@@ -1,7 +1,6 @@
 defmodule ArchethicPlaygroundWeb.EditorLive do
   @moduledoc false
 
-  alias ArchethicPlayground.Utils
   alias ArchethicPlayground.Transaction
   alias ArchethicPlayground.TriggerForm
   alias ArchethicPlaygroundWeb.ConsoleComponent
@@ -11,15 +10,13 @@ defmodule ArchethicPlaygroundWeb.EditorLive do
   alias ArchethicPlaygroundWeb.HeaderComponent
   alias ArchethicPlaygroundWeb.SidebarComponent
   alias ArchethicPlaygroundWeb.TriggerComponent
+
   alias Archethic.Contracts.Contract
 
   use ArchethicPlaygroundWeb, :live_view
 
   def mount(_params, _opts, socket) do
     code = default_code()
-
-    # we define a random address so we can prefill the trigger transaction recipients
-    random_address = Utils.Address.random() |> Base.encode16()
 
     socket =
       socket
@@ -33,7 +30,6 @@ defmodule ArchethicPlaygroundWeb.EditorLive do
         functions: [],
         transaction_contract:
           Transaction.new(%{
-            "address" => random_address,
             "type" => "contract",
             "code" => code
           })
@@ -159,11 +155,6 @@ defmodule ArchethicPlaygroundWeb.EditorLive do
           )
 
           if replace_contract? do
-            # hack:
-            # we give the transaction the same address as previous so we can chain without having to
-            # update the recipients on the trigger form
-            tx = %Transaction{tx | address: socket.assigns.transaction_contract.address}
-
             socket
             |> assign(transaction_contract: tx)
             |> push_event("set-code", %{"code" => tx.code})

--- a/lib/archethic_playground_web/live/editor_live.ex
+++ b/lib/archethic_playground_web/live/editor_live.ex
@@ -119,7 +119,7 @@ defmodule ArchethicPlaygroundWeb.EditorLive do
            args_values
          ) do
       {:ok, result} ->
-        send(self(), {:console, :success, "Result: #{inspect(result)}"})
+        send(self(), {:console, :success, result})
 
       {:error, :function_failure} ->
         send(self(), {:console, :error, "Function failed"})

--- a/lib/archethic_playground_web/live/editor_live.html.heex
+++ b/lib/archethic_playground_web/live/editor_live.html.heex
@@ -19,7 +19,7 @@
             module={TriggerComponent}
             id={TriggerComponent.id()}
             triggers={@triggers}
-            contract_address={@transaction_contract.address}
+            transaction={@transaction_contract}
           />
         <% end %>
         <%= if @left_panel == "function" do %>


### PR DESCRIPTION
Bit of refactor here and there also. 
- `Contract.add_ownerships/2` now works. It requires the user to have pre-encoded the secret and encrypted key.
- Secret form changed in consequence. 
- Address are not random anymore, there is a random seed and we derive address from it 
- Mock Storage nonce
- Automatically add the contract ownership
- Sign the transactions via the seed 

To be deployed when https://github.com/archethic-foundation/archethic-node/pull/1269 is deployed to testnet (1.3.1 AFAIK)

 