### PR TITLE
Adapt to 1.5.0 and display the logs in the console

### DIFF
--- a/lib/archethic_playground_web/live/components/mock_form_component/chain_get_last_transaction1.ex
+++ b/lib/archethic_playground_web/live/components/mock_form_component/chain_get_last_transaction1.ex
@@ -4,7 +4,7 @@ defmodule ArchethicPlaygroundWeb.MockFormComponent.ChainGetLastTransaction1 do
   alias ArchethicPlayground.Transaction
   alias ArchethicPlayground.Mock
   alias ArchethicPlaygroundWeb.TransactionFormComponent
-  alias Archethic.Contracts.ContractConstants, as: Constants
+  alias Archethic.Contracts.Constants
 
   use ArchethicPlaygroundWeb, :live_component
 

--- a/lib/archethic_playground_web/live/components/mock_form_component/chain_get_transaction1.ex
+++ b/lib/archethic_playground_web/live/components/mock_form_component/chain_get_transaction1.ex
@@ -4,7 +4,7 @@ defmodule ArchethicPlaygroundWeb.MockFormComponent.ChainGetTransaction1 do
   alias ArchethicPlayground.Transaction
   alias ArchethicPlayground.Mock
   alias ArchethicPlaygroundWeb.TransactionFormComponent
-  alias Archethic.Contracts.ContractConstants, as: Constants
+  alias Archethic.Contracts.Constants
 
   use ArchethicPlaygroundWeb, :live_component
 


### PR DESCRIPTION
- Use new Interpreter API
- Display logs in the console


Examples of scenario to try
```
@version 1

condition triggered_by: transaction do 
  true
end

actions triggered_by: transaction do
  Playground.print("hello from action")
  Playground.print("hello from action 2")
  throw "toto"
end
```

```
@version 1

condition triggered_by: transaction, as: [
  content:
   (
    Playground.print("hello from condition content")
    throw "invalid content encoding"
    )
]

actions triggered_by: transaction do
  Contract.set_content "ok"
end
```

```
@version 1

condition triggered_by: transaction do 
    Playground.print("hello from condition block")
  throw "no no"
end

actions triggered_by: transaction do
  Contract.set_content "ok"
end
```